### PR TITLE
Update class-utility.php

### DIFF
--- a/lib/classes/class-utility.php
+++ b/lib/classes/class-utility.php
@@ -68,11 +68,7 @@ namespace UsabilityDynamics\WP {
             $path = get_template_directory_uri() . $p;
             break;
           case 'stylesheet':
-            $s = str_replace( wp_normalize_path( ABSPATH ), '', get_stylesheet_directory() );
-            $s = str_replace( '/', '\/', $s );
-            $reg = '|^(.)*(' . $s . ')(.*)$|';
-            $p = preg_replace( $reg, '$3', wp_normalize_path( dirname( __FILE__ ) ) );
-            $path = get_stylesheet_directory_uri() . $p;
+            $path = WP_CONTENT_URL . str_replace( wp_normalize_path( WP_CONTENT_DIR ), '', wp_normalize_path( dirname( __FILE__ ) ) );
             break;
         }
         return $path;


### PR DESCRIPTION
`_path_url` works incorrectly a) on Windows with backslashes breaking regex; b) when WP_CONTENT_DIR and _URL are not in the ABSPATH.

Fixed the stylesheet part. Same should be done with the template.