### PR TITLE
Fix notice about translations loaded too soon

### DIFF
--- a/lib/classes/class-bootstrap-plugin.php
+++ b/lib/classes/class-bootstrap-plugin.php
@@ -33,7 +33,7 @@ namespace UsabilityDynamics\WP {
         //** Maybe define license client */
         $this->define_license_client();
         //** Load text domain */
-        add_action( 'plugins_loaded', array( $this, 'load_textdomain' ), 1 );
+        add_action( 'init', array( $this, 'load_textdomain' ), 1 );
         //** May be initialize Licenses Manager. */
         add_action( 'plugins_loaded', array( $this, 'define_license_manager' ), 1 );
         //** Initialize plugin here. All plugin actions must be added on this step */

--- a/lib/classes/class-bootstrap-theme.php
+++ b/lib/classes/class-bootstrap-theme.php
@@ -49,7 +49,7 @@ namespace UsabilityDynamics\WP {
       protected function __construct( $args ) {
         parent::__construct( $args );
         //** Load text domain */
-        add_action( 'after_setup_theme', array( $this, 'load_textdomain' ), 1 );
+        add_action( 'init', array( $this, 'load_textdomain' ), 1 );
         //** TGM Plugin activation. */
         $this->check_plugins_requirements();
         //** May be initialize Licenses Manager. */


### PR DESCRIPTION
Ref: https://instawp.com/function-load-textdomain-just-in-time-was-called-incorrectly/

Fixes: https://github.com/udx/wp-stateless/issues/804